### PR TITLE
Add additional fields

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
-  "name": "Webhook 2 Notion table",
-  "description": "Create a webhook where you can send todo's that will be added to your notion account",
-  "repository": "https://git.heroku.com/nameless-scrubland-94978.git",
-  "keywords": ["notion", "webhook", "notion-py"]
+  "name": "Goodreads Update to Notion",
+  "description": "Create a webhook where you can send a Goodreads status update to a Notion table",
+  "repository": "https://git.heroku.com/notion-goodreads-updates.git",
+  "keywords": ["notion", "webhook", "notion-py", "calibre", "goodreads"]
 }

--- a/app.py
+++ b/app.py
@@ -41,7 +41,7 @@ def addGoodReadsPercent(token, collectionURL, title, percent, date):
     percent = int(percent)
     percent = float(percent/100)
     row.percent = percent
-    titleDate = datetime.datetime.strftime(date, "%M %d %Y")
+    titleDate = datetime.strftime(date, "%M %d %Y")
     title = title + " | " + titleDate
     row.title = title
 

--- a/app.py
+++ b/app.py
@@ -28,7 +28,7 @@ def create_todo():
     createNotionTask(token_v2, url, todo)
     return f'added {todo} to Notion'
 
-def addGoodReadsPercent(token, collectionURL, date, percent):
+def addGoodReadsPercent(token, collectionURL, percent, date):
     # notion
     client = NotionClient(token)
     cv = client.get_collection_view(collectionURL)

--- a/app.py
+++ b/app.py
@@ -41,7 +41,8 @@ def addGoodReadsPercent(token, collectionURL, title, percent, date):
     percent = int(percent)
     percent = float(percent/100)
     row.percent = percent
-    title = title + " | " + str(date)
+    titleDate = datetime.datetime.strftime(date, "%M %d %Y")
+    title = title + " | " + titleDate
     row.title = title
 
 

--- a/app.py
+++ b/app.py
@@ -35,7 +35,9 @@ def addGoodReadsPercent(token, collectionURL, percent):
     row = cv.collection.add_row()
     row.title = "Test123"
     #CST = tz.gettz('America/Chicago')
-    row.date = datetime.now()
+    dateTest = "2020-11-05 10:49:18"
+    date2 = parser.parse(dateTest)
+    row.date = date2
     percent = int(percent)
     percent = float(percent/100)
     row.percent = percent

--- a/app.py
+++ b/app.py
@@ -41,7 +41,7 @@ def addGoodReadsPercent(token, collectionURL, title, percent, date):
     percent = int(percent)
     percent = float(percent/100)
     row.percent = percent
-    title = title + " | " + str(date)
+    title = title + " | " + str(row.date)
     row.title = title
 
 

--- a/app.py
+++ b/app.py
@@ -35,7 +35,7 @@ def addGoodReadsPercent(token, collectionURL, percent):
     row = cv.collection.add_row()
     row.title = "Test123"
     #CST = tz.gettz('America/Chicago')
-    row.date = datetime.now(tzlocal())
+    row.date = datetime.now(tz.tzlocal())
     percent = int(percent)
     percent = float(percent/100)
     row.percent = percent

--- a/app.py
+++ b/app.py
@@ -34,8 +34,8 @@ def addGoodReadsPercent(token, collectionURL, percent):
     cv = client.get_collection_view(collectionURL)
     row = cv.collection.add_row()
     row.title = "Test123"
-    #CST = tz.gettz('America/Chicago')
-    row.date = datetime.now(tz.tzlocal())
+    CST = tz.gettz('America/Chicago')
+    row.date = datetime.now(CST)
     percent = int(percent)
     percent = float(percent/100)
     row.percent = percent

--- a/app.py
+++ b/app.py
@@ -1,5 +1,8 @@
 
 import os
+from dateutil import parser
+from dateutil import tz
+from datetime import datetime
 from notion.client import NotionClient
 from flask import Flask
 from flask import request
@@ -31,7 +34,7 @@ def addGoodReadsPercent(token, collectionURL, percent):
     cv = client.get_collection_view(collectionURL)
     row = cv.collection.add_row()
     row.title = "Test123"
-    row.date = now()
+    row.date = datetime.now(tz.UTC)
     percent = int(percent)
     percent = float(percent/100)
     row.percent = percent

--- a/app.py
+++ b/app.py
@@ -41,7 +41,7 @@ def addGoodReadsPercent(token, collectionURL, title, percent, date):
     percent = int(percent)
     percent = float(percent/100)
     row.percent = percent
-    title = title + " | " + date
+    title = title + " | " + str(date)
     row.title = title
 
 

--- a/app.py
+++ b/app.py
@@ -47,7 +47,7 @@ def addGoodReadsPercent(token, collectionURL, date, percent):
 def add_percent():
 
     percent = request.args.get('percent')
-    date = request.args.get('date')
+    date = str(request.args.get('date'))
     token_v2 = os.environ.get("TOKEN")
     url = os.environ.get("URL")
     addGoodReadsPercent(token_v2, url, percent, date)

--- a/app.py
+++ b/app.py
@@ -25,28 +25,27 @@ def create_todo():
     createNotionTask(token_v2, url, todo)
     return f'added {todo} to Notion'
 
-def addGoodReadsPercent(token, collectionURL, percent, date):
+def addGoodReadsPercent(token, collectionURL, percent):
     # notion
     client = NotionClient(token)
     cv = client.get_collection_view(collectionURL)
     row = cv.collection.add_row()
     row.title = "Test123"
+    row.date = now()
     percent = int(percent)
     percent = float(percent/100)
     row.percent = percent
-    date = "2020-10-28 00:49:18 -0000"
-    row.date = date
 
 
 @app.route('/add_percent', methods=['GET'])
 def add_percent():
 
     percent = request.args.get('percent')
-    date = request.args.get('date')
+    #date = request.args.get('date')
     token_v2 = os.environ.get("TOKEN")
     url = os.environ.get("URL")
-    addGoodReadsPercent(token_v2, url, percent, date)
-    return f'added {percent} on {date} to Notion'
+    addGoodReadsPercent(token_v2, url, percent)
+    return f'added {percent} to Notion'
 
 
 if __name__ == '__main__':

--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ def addGoodReadsPercent(token, collectionURL, percent):
     cv = client.get_collection_view(collectionURL)
     row = cv.collection.add_row()
     row.title = "Test123"
-    row.date = datetime.now(tz.UTC)
+    row.date = datetime.now()
     percent = int(percent)
     percent = float(percent/100)
     row.percent = percent

--- a/app.py
+++ b/app.py
@@ -34,8 +34,9 @@ def addGoodReadsPercent(token, collectionURL, percent):
     cv = client.get_collection_view(collectionURL)
     row = cv.collection.add_row()
     row.title = "Test123"
-    CST = tz.gettz('America/Chicago')
-    row.date = datetime.now(CST)
+    #CST = tz.gettz('America/Chicago')
+    #now = datetime.now()
+    row.date = cv.NotionDate(datetime.now())
     percent = int(percent)
     percent = float(percent/100)
     row.percent = percent

--- a/app.py
+++ b/app.py
@@ -50,7 +50,7 @@ def addGoodReadsPercent(token, collectionURL, collectionURLBook, title, percent)
     #row.title = title
     #CST = tz.gettz('America/Chicago')
     #dateTest = "2020-11-05 10:49:18"
-    date = parser.parse(datetime.now())
+    date = datetime.now()
     row.date = date
     percent = int(percent)
     percent = float(percent/100)

--- a/app.py
+++ b/app.py
@@ -41,7 +41,7 @@ def addGoodReadsPercent(token, collectionURL, title, percent, date):
     percent = int(percent)
     percent = float(percent/100)
     row.percent = percent
-    title = title + " | " + str(row.date)
+    title = title + " | " + str(date)
     row.title = title
 
 

--- a/app.py
+++ b/app.py
@@ -41,7 +41,7 @@ def addGoodReadsPercent(token, collectionURL, title, percent, date):
     percent = int(percent)
     percent = float(percent/100)
     row.percent = percent
-    titleDate = datetime.strftime(date, "%M %d %Y")
+    titleDate = datetime.strftime(date, "%m/%d/%Y")
     title = title + " | " + titleDate
     row.title = title
 

--- a/app.py
+++ b/app.py
@@ -28,16 +28,16 @@ def create_todo():
     createNotionTask(token_v2, url, todo)
     return f'added {todo} to Notion'
 
-def addGoodReadsPercent(token, collectionURL, percent):
+def addGoodReadsPercent(token, collectionURL, date, percent):
     # notion
     client = NotionClient(token)
     cv = client.get_collection_view(collectionURL)
     row = cv.collection.add_row()
     row.title = "Test123"
     #CST = tz.gettz('America/Chicago')
-    dateTest = "2020-11-05 10:49:18"
-    date2 = parser.parse(dateTest)
-    row.date = date2
+    #dateTest = "2020-11-05 10:49:18"
+    date = parser.parse(date)
+    row.date = date
     percent = int(percent)
     percent = float(percent/100)
     row.percent = percent
@@ -47,10 +47,10 @@ def addGoodReadsPercent(token, collectionURL, percent):
 def add_percent():
 
     percent = request.args.get('percent')
-    #date = request.args.get('date')
+    date = request.args.get('date')
     token_v2 = os.environ.get("TOKEN")
     url = os.environ.get("URL")
-    addGoodReadsPercent(token_v2, url, percent)
+    addGoodReadsPercent(token_v2, url, percent, date)
     return f'added {percent} to Notion'
 
 

--- a/app.py
+++ b/app.py
@@ -57,7 +57,7 @@ def addGoodReadsPercent(token, collectionURL, collectionURLBook, title, percent,
 @app.route('/add_percent', methods=['GET'])
 def add_percent():
 
-    title = request.args.get('title')
+    title = str(request.args.get('title'))
     percent = request.args.get('percent')
     date = str(request.args.get('date'))
     token_v2 = os.environ.get("TOKEN")

--- a/app.py
+++ b/app.py
@@ -28,13 +28,19 @@ def create_todo():
     createNotionTask(token_v2, url, todo)
     return f'added {todo} to Notion'
 
+def fix_title(title):
+    first, rest = title.split(None, 1)
+    if first in {'A', 'An', 'The'}:
+        return rest + ', ' + first
+    return title
+
 def getBook(token, collectionURLBook, title):
     client = NotionClient(token)
     cvBook = client.get_collection_view(collectionURLBook)
-    bookName = str(title)
-    for row in cvBook.collection.get_rows(search=bookName):
-        authorId = row.id
-        return authorId
+    for row in cvBook.collection.get_rows(search=title):
+        if row.title == fix_title(title):
+            authorId = row.id
+            return authorId
 
 def addGoodReadsPercent(token, collectionURL, collectionURLBook, title, percent, date):
     # notion

--- a/app.py
+++ b/app.py
@@ -31,7 +31,8 @@ def create_todo():
 def getBook(token, collectionURLBook, title):
     client = NotionClient(token)
     cvBook = client.get_collection_view(collectionURLBook)
-    for row in cvBook.collection.get_rows(search=title):
+    bookName = str(title)
+    for row in cvBook.collection.get_rows(search=bookName):
         authorId = row.id
         return authorId
 
@@ -57,7 +58,7 @@ def addGoodReadsPercent(token, collectionURL, collectionURLBook, title, percent,
 @app.route('/add_percent', methods=['GET'])
 def add_percent():
 
-    title = str(request.args.get('title'))
+    title = request.args.get('title')
     percent = request.args.get('percent')
     date = str(request.args.get('date'))
     token_v2 = os.environ.get("TOKEN")

--- a/app.py
+++ b/app.py
@@ -56,8 +56,8 @@ def addGoodReadsPercent(token, collectionURL, collectionURLBook, title, percent,
     percent = float(percent/100)
     row.percent = percent
     titleDate = datetime.strftime(date, "%m/%d/%Y")
-    title = title + " | " + titleDate
-    row.title = title
+    titleBook = title + " | " + titleDate
+    row.title = titleBook
     row.book = getBook(token, collectionURLBook, title)
 
 

--- a/app.py
+++ b/app.py
@@ -28,12 +28,12 @@ def create_todo():
     createNotionTask(token_v2, url, todo)
     return f'added {todo} to Notion'
 
-def addGoodReadsPercent(token, collectionURL, percent, date):
+def addGoodReadsPercent(token, collectionURL, title, percent, date):
     # notion
     client = NotionClient(token)
     cv = client.get_collection_view(collectionURL)
     row = cv.collection.add_row()
-    row.title = "Test123"
+    #row.title = title
     #CST = tz.gettz('America/Chicago')
     #dateTest = "2020-11-05 10:49:18"
     date = parser.parse(date)
@@ -41,16 +41,19 @@ def addGoodReadsPercent(token, collectionURL, percent, date):
     percent = int(percent)
     percent = float(percent/100)
     row.percent = percent
+    title = title + " | " + date
+    row.title = title
 
 
 @app.route('/add_percent', methods=['GET'])
 def add_percent():
 
+    title = request.args.get('title')
     percent = request.args.get('percent')
     date = str(request.args.get('date'))
     token_v2 = os.environ.get("TOKEN")
     url = os.environ.get("URL")
-    addGoodReadsPercent(token_v2, url, percent, date)
+    addGoodReadsPercent(token_v2, url, title, percent, date)
     return f'added {percent} to Notion'
 
 

--- a/app.py
+++ b/app.py
@@ -35,8 +35,7 @@ def addGoodReadsPercent(token, collectionURL, percent):
     row = cv.collection.add_row()
     row.title = "Test123"
     #CST = tz.gettz('America/Chicago')
-    #now = datetime.now()
-    row.date = cv.NotionDate(datetime.now())
+    row.date = datetime.now()
     percent = int(percent)
     percent = float(percent/100)
     row.percent = percent

--- a/app.py
+++ b/app.py
@@ -42,7 +42,7 @@ def getBook(token, collectionURLBook, title):
             authorId = row.id
             return authorId
 
-def addGoodReadsPercent(token, collectionURL, collectionURLBook, title, percent, date):
+def addGoodReadsPercent(token, collectionURL, collectionURLBook, title, percent):
     # notion
     client = NotionClient(token)
     cv = client.get_collection_view(collectionURL)
@@ -50,7 +50,7 @@ def addGoodReadsPercent(token, collectionURL, collectionURLBook, title, percent,
     #row.title = title
     #CST = tz.gettz('America/Chicago')
     #dateTest = "2020-11-05 10:49:18"
-    date = parser.parse(date)
+    date = parser.parse(datetime.now())
     row.date = date
     percent = int(percent)
     percent = float(percent/100)
@@ -64,14 +64,14 @@ def addGoodReadsPercent(token, collectionURL, collectionURLBook, title, percent,
 @app.route('/add_percent', methods=['GET'])
 def add_percent():
 
-    title = str(request.args.get('title'))
+    title = str(os.environ.get('TITLE'))
     percent = request.args.get('percent')
-    date = str(request.args.get('date'))
+    #date = str(request.args.get('date'))
     token_v2 = os.environ.get("TOKEN")
     url = os.environ.get("URL")
     urlb = os.environ.get("URLB")
-    addGoodReadsPercent(token_v2, url, urlb, title, percent, date)
-    return f'added {percent} for {title} on {date} to Notion'
+    addGoodReadsPercent(token_v2, url, urlb, title, percent)
+    return f'added {percent} for {title} to Notion'
 
 
 if __name__ == '__main__':

--- a/app.py
+++ b/app.py
@@ -64,7 +64,7 @@ def addGoodReadsPercent(token, collectionURL, collectionURLBook, title, percent,
 @app.route('/add_percent', methods=['GET'])
 def add_percent():
 
-    title = request.args.get('title')
+    title = str(request.args.get('title'))
     percent = request.args.get('percent')
     date = str(request.args.get('date'))
     token_v2 = os.environ.get("TOKEN")

--- a/app.py
+++ b/app.py
@@ -28,7 +28,14 @@ def create_todo():
     createNotionTask(token_v2, url, todo)
     return f'added {todo} to Notion'
 
-def addGoodReadsPercent(token, collectionURL, title, percent, date):
+def getBook(token, collectionURLBook, title):
+    client = NotionClient(token)
+    cvBook = client.get_collection_view(collectionURLBook)
+    for row in cvBook.collection.get_rows(search=title):
+        authorId = row.id
+        return authorId
+
+def addGoodReadsPercent(token, collectionURL, collectionURLBook, title, percent, date):
     # notion
     client = NotionClient(token)
     cv = client.get_collection_view(collectionURL)
@@ -44,6 +51,7 @@ def addGoodReadsPercent(token, collectionURL, title, percent, date):
     titleDate = datetime.strftime(date, "%m/%d/%Y")
     title = title + " | " + titleDate
     row.title = title
+    row.book = getBook(token, collectionURLBook, title)
 
 
 @app.route('/add_percent', methods=['GET'])
@@ -54,8 +62,9 @@ def add_percent():
     date = str(request.args.get('date'))
     token_v2 = os.environ.get("TOKEN")
     url = os.environ.get("URL")
-    addGoodReadsPercent(token_v2, url, title, percent, date)
-    return f'added {percent} to Notion'
+    urlb = os.environ.get("URLB")
+    addGoodReadsPercent(token_v2, url, urlb, title, percent, date)
+    return f'added {percent} for {title} on {date} to Notion'
 
 
 if __name__ == '__main__':

--- a/app.py
+++ b/app.py
@@ -25,7 +25,7 @@ def create_todo():
     createNotionTask(token_v2, url, todo)
     return f'added {todo} to Notion'
 
-def addGoodReadsPercent(token, collectionURL, percent):
+def addGoodReadsPercent(token, collectionURL, percent, date):
     # notion
     client = NotionClient(token)
     cv = client.get_collection_view(collectionURL)
@@ -34,16 +34,19 @@ def addGoodReadsPercent(token, collectionURL, percent):
     percent = int(percent)
     percent = float(percent/100)
     row.percent = percent
+    date = "2020-10-28 00:49:18 -0000"
+    row.date = date
 
 
 @app.route('/add_percent', methods=['GET'])
 def add_percent():
 
     percent = request.args.get('percent')
+    date = request.args.get('date')
     token_v2 = os.environ.get("TOKEN")
     url = os.environ.get("URL")
-    addGoodReadsPercent(token_v2, url, percent)
-    return f'added {percent} to Notion'
+    addGoodReadsPercent(token_v2, url, percent, date)
+    return f'added {percent} on {date} to Notion'
 
 
 if __name__ == '__main__':

--- a/app.py
+++ b/app.py
@@ -34,7 +34,8 @@ def addGoodReadsPercent(token, collectionURL, percent):
     cv = client.get_collection_view(collectionURL)
     row = cv.collection.add_row()
     row.title = "Test123"
-    row.date = datetime.now()
+    #CST = tz.gettz('America/Chicago')
+    row.date = datetime.now(tzlocal())
     percent = int(percent)
     percent = float(percent/100)
     row.percent = percent

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 Flask==0.10.1
 notion
+dateutil
+datetime

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask==0.10.1
 notion
-dateutil
+python-dateutil
 datetime


### PR DESCRIPTION
Needed to remove the ability to add multiple arguments through Flask. Originally going to use Zapier, but that didn't work out due to being on their free plan. Now I'm handling both Title and Date directly through the Flask application and only using Zapier to grab and send the percent.